### PR TITLE
Inline-block the separator; Delete useless placeholder line-height

### DIFF
--- a/components/phone_input.css
+++ b/components/phone_input.css
@@ -1,18 +1,11 @@
-.intlPhone-dialCode, .intlPhone-phoneNumber {
+.intlPhone-dialCode,
+.intlPhone-phoneNumber,
+.intlPhone-separator {
   display: inline-block;
-  vertical-align: top;
+  vertical-align: middle;
   border: none;
   outline: none;
   height: 100%;
   float: left;
-}
-
-::-webkit-input-placeholder {
-  line-height: 1.4;
-}
-::-moz-placeholder {
-  line-height: 1.4;
-}
-:-ms-input-placeholder {
-  line-height: 1.4;
+  text-align: right;
 }


### PR DESCRIPTION
Inline-block the new `.separator` to make sure it doesn't break flow when _not in a flex-box_.

Placeholder `line-height` was set to incorrect value and should just be inherited. No idea why I put it there in the first place :older_man:
