### PR TITLE
Add 'type=number' to dialCode input

### DIFF
--- a/components/phone_input.html
+++ b/components/phone_input.html
@@ -4,7 +4,8 @@
       autocomplete="off"
       name="dialCode"
       value="{{dialCode}}"
-      maxlength="4" />
+      maxlength="4"
+      type="number" />
 
     {{#if showSeparator}}
       <div class="intlPhone-separator separator"></div>


### PR DESCRIPTION
The dialcode input was not opening the numerical keyboard on mobile. As the `+` sign is automatically added, the user should only be given a numerical keyboard. Changing the input `type` to `number` solves the problem.
