### PR TITLE
Fixed capitalization that breaks in Meteor 1.3

### DIFF
--- a/package.js
+++ b/package.js
@@ -20,7 +20,7 @@ Package.onUse(function (api) {
 
   api.addFiles([
     'google.phoneformat.js',
-    'phoneformat.js',
+    'PhoneFormat.js',
     'country_code_map.js',
     'components/single-input/single_input.html',
     'components/single-input/single_input.js',


### PR DESCRIPTION
When this module is installed locally (vs from atmosphere), it breaks under Meteor 1.3 (in Windows 10, at least) because the filename capitalization in package.js doesn't match the PhoneFormat.js file.
